### PR TITLE
Documentation enhancements

### DIFF
--- a/{{cookiecutter.collection_name}}/MAINTAINERS.md
+++ b/{{cookiecutter.collection_name}}/MAINTAINERS.md
@@ -65,6 +65,14 @@ For information about the use and development of tasks and flow, check out the [
 
 This collection has been setup to with [mkdocs](https://www.mkdocs.org/) for automatically generated documentation. The signatures and docstrings of your tasks and flow will be used to generate documentation for the users of this collection. You can make changes to the structure of the generated documentation by editing the `mkdocs.yml` file in this project.
 
+To add a new page for a module in your collection, create a new markdown file in the `docs` directory and add that file to the `nav` section of `mkdocs.yml`. If you want to automatically generate documentation based on the docstrings and signatures of the contents of the module with `mkdocstrings`, add a line to the new markdown file in the following format:
+
+```markdown
+::: {{ cookiecutter.collection_slug }}.{module_name}
+```
+
+You can also refer to the `flows.md` and `tasks.md` files included in your generated project as examples.
+
 ## Development lifecycle
 
 ### CI Pipeline

--- a/{{cookiecutter.collection_name}}/mkdocs.yml
+++ b/{{cookiecutter.collection_name}}/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: {{ cookiecutter.collection_name }}
+repo_url: https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.collection_name }}
 theme:
   name: material
   palette:


### PR DESCRIPTION
- Adds documentation to MAINTAINERS.md to explain how to create new doc pages that pull from docstrings
    - Closes #35 
- Add repo_url to mkdocs.yml so that generated collections will automatically have links to their repositories in the documentation header
    - Closes #40 
- Adds empty CODEOWNERS file to generated projects
    - Closes #34  