### PR TITLE
Removes git init and commit on post project generation

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -34,8 +34,8 @@ jobs:
         # Initializes test git project to ensure pre-commit runs correctly
         run: |
           cd prefect-collection
+          git init
           git config user.email "test@example.com"
           git config user.name "Test"
-          git init
           git commit -am "Test commit"
           pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -33,4 +33,6 @@ jobs:
         # Runs pre-commit on the generated collection to ensure the code styling is compliant
         run: |
           cd prefect-collection
+          git init
+          git commit -am "Test commit"
           pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -31,8 +31,11 @@ jobs:
 
       - name: Run pre-commit on generated collection
         # Runs pre-commit on the generated collection to ensure the code styling is compliant
+        # Initializes test git project to ensure pre-commit runs correctly
         run: |
           cd prefect-collection
+          git config user.email "test@example.com"
+          git config user.name "Test"
           git init
           git commit -am "Test commit"
           pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -37,5 +37,6 @@ jobs:
           git init
           git config user.email "test@example.com"
           git config user.name "Test"
-          git commit -am "Test commit"
+          git add .
+          git commit -m "Test commit"
           pre-commit run --show-diff-on-failure --color=always --all-files

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,5 +1,5 @@
-import subprocess
-
-subprocess.call(["git", "init"])
-subprocess.call(["git", "add", "*"])
-subprocess.call(["git", "commit", "-m", "Initial commit"])
+print(
+    "Your Prefect Collection has been generated! Please refer"
+    "to MAINTAINERS.md in the generated project for the next steps"
+    "developing your Prefect Collection"
+)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,5 +1,5 @@
 print(
-    "Your Prefect Collection has been generated! Please refer"
-    "to MAINTAINERS.md in the generated project for the next steps"
+    "Your Prefect Collection has been generated! Please refer "
+    "to MAINTAINERS.md in the generated project for the next steps "
     "developing your Prefect Collection"
 )


### PR DESCRIPTION
Removes git initialization in anticipation of introducing [cruft](https://cruft.github.io/cruft/) to manage template change propagation. Initializing a git project inhibits cruft from performing automatic updates based on changes to a cookiecutter template.