### PR TITLE
Update GitHub edit path and page frontmatter

### DIFF
--- a/{{cookiecutter.collection_name}}/docs/flows.md
+++ b/{{cookiecutter.collection_name}}/docs/flows.md
@@ -1,1 +1,6 @@
+---
+description: 
+notes: This documentation page is generated from source file docstrings.
+---
+
 ::: {{ cookiecutter.collection_slug }}.flows

--- a/{{cookiecutter.collection_name}}/docs/tasks.md
+++ b/{{cookiecutter.collection_name}}/docs/tasks.md
@@ -1,1 +1,6 @@
+---
+description: 
+notes: This documentation page is generated from source file docstrings.
+---
+
 ::: {{ cookiecutter.collection_slug }}.tasks

--- a/{{cookiecutter.collection_name}}/mkdocs.yml
+++ b/{{cookiecutter.collection_name}}/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: {{ cookiecutter.collection_name }}
 site_url: https://{{ cookiecutter.github_organization }}.github.io/{{ cookiecutter.collection_name }}
 repo_url: https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.collection_name }}
-edit_uri: /edit/main/docs/
+edit_uri: edit/main/docs/
 theme:
   name: material
   favicon: img/favicon.ico


### PR DESCRIPTION
Fix misconfigured edit path to enable submitting edits via the "Pencil" edit link.

In addition:

- Adds yaml frontmatter to generated doc pages
- Frontmatter includes a note indicating that API pages are generated from docstrings in source files. 