### PR TITLE
Create add-to-project.yml

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add issues to integrations board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: ${{ secrets.ADD_TO_PROJECT_URL }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -6,11 +6,19 @@ on:
       - opened
 
 jobs:
+
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        name: Generate GitHub token
+        with:
+          app_id: ${{ secrets.SYNC_APP_ID }}
+          private_key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+
       - uses: actions/add-to-project@v0.3.0
         with:
           project-url: ${{ secrets.ADD_TO_PROJECT_URL }}
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ steps.generate-token.outputs.token }}

--- a/{{cookiecutter.collection_name}}/MAINTAINERS.md
+++ b/{{cookiecutter.collection_name}}/MAINTAINERS.md
@@ -93,6 +93,12 @@ This collection comes with [GitHub Actions](https://docs.github.com/en/actions) 
 
 Simiarly, `coverage` ensures that the codebase includes tests--the job has a fail threshold of 80%, meaning that it will fail if more than 20% of the codebase is missing tests.
 
+### Track Issues on Project Board
+
+To automatically add issues to a GitHub Project Board, you'll need two [secrets added](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-environment) to the repository:
+1. `ADD_TO_PROJECT_URL`: URL to the project board, formatted like `https://github.com/orgs/<GITHUB_ORGANIZATION>/projects/<PROJECT_NUMBER>`.
+2. `ADD_TO_PROJECT_PAT`: personal access token with `repo` and `project` scopes; click [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to see how to create one.
+
 ### Package and Publish
 
 GitHub actions will handle packaging and publishing of your collection to [PyPI](https://pypi.org/) so other Prefect users can your collection in their flows.

--- a/{{cookiecutter.collection_name}}/MAINTAINERS.md
+++ b/{{cookiecutter.collection_name}}/MAINTAINERS.md
@@ -95,9 +95,7 @@ Simiarly, `coverage` ensures that the codebase includes tests--the job has a fai
 
 ### Track Issues on Project Board
 
-To automatically add issues to a GitHub Project Board, you'll need two [secrets added](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-environment) to the repository:
-1. `ADD_TO_PROJECT_URL`: URL to the project board, formatted like `https://github.com/orgs/<GITHUB_ORGANIZATION>/projects/<PROJECT_NUMBER>`.
-2. `ADD_TO_PROJECT_PAT`: personal access token with `repo` and `project` scopes; click [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to see how to create one.
+To automatically add issues to a GitHub Project Board, you'll need a [secret added](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-an-environment) to the repository. Specifically, a secret named `ADD_TO_PROJECT_URL`, formatted like `https://github.com/orgs/<GITHUB_ORGANIZATION>/projects/<PROJECT_NUMBER>`.
 
 ### Package and Publish
 


### PR DESCRIPTION
Automatically adds new issues to the Integrations board.

Tested on `prefect-airbyte` with https://github.com/PrefectHQ/prefect-airbyte/issues/33.

To get this working per collection, users need to add two secrets to each repository, specifically these two
`ADD_TO_PROJECT_URL` which is formatted like `https://github.com/orgs/<GITHUB_ORG>/projects/<#>` and also `ADD_TO_PROJECT_PAT`

Also, how do we handle these PAT? Can we get a secret from the Prefect org instead of us individually creating one?

Once we get an org wide PAT, @zzstoatzz needs to update the `prefect-airbyte` secret

Closes https://github.com/PrefectHQ/integrations-tools/issues/3

Worked on this with @zzstoatzz 