### PR TITLE
Set show_category_heading and show_bases to True

### DIFF
--- a/{{cookiecutter.collection_name}}/mkdocs.yml
+++ b/{{cookiecutter.collection_name}}/mkdocs.yml
@@ -38,8 +38,8 @@ plugins:
           rendering:
             show_root_heading: True
             show_object_full_path: False
-            show_category_heading: False
-            show_bases: False
+            show_category_heading: True
+            show_bases: True
             show_signature: False
             heading_level: 1
       watch:


### PR DESCRIPTION
Groups by functions/classes/etc and shows the inherited class like
![image](https://user-images.githubusercontent.com/15331990/194629611-2918b42a-de2f-4a84-8a5d-22af033c9f52.png)
