### PR TITLE
Fix mkdocstrings deprecation warnings

### DIFF
--- a/{{cookiecutter.collection_name}}/mkdocs.yml
+++ b/{{cookiecutter.collection_name}}/mkdocs.yml
@@ -35,16 +35,16 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          rendering:
+          options:
             show_root_heading: True
             show_object_full_path: False
             show_category_heading: True
             show_bases: True
             show_signature: False
             heading_level: 1
-      watch:
-        - {{ cookiecutter.collection_slug }}/
-        - README.md
+watch:
+    - {{ cookiecutter.collection_slug }}/
+    - README.md
 
 nav:
     - Home: index.md


### PR DESCRIPTION
Fixes
```
INFO     -  DeprecationWarning: mkdocstrings' watch feature is deprecated in favor of MkDocs' watch feature, see https://www.mkdocs.org/user-guide/configuration/#watch.
              File "/Users/andrew/mambaforge/envs/docker/lib/python3.9/site-packages/mkdocs/plugins.py", line 514, in run_event
                result = method(item, **kwargs)
              File "/Users/andrew/mambaforge/envs/docker/lib/python3.9/site-packages/mkdocstrings/plugin.py", line 129, in on_serve
                warn(
INFO     -  DeprecationWarning: 'selection' and 'rendering' are deprecated and merged into a single 'options' YAML key
              File "/Users/andrew/mambaforge/envs/docker/lib/python3.9/site-packages/mkdocstrings/extension.py", line 121, in run
                html, handler, data = self._process_block(identifier, block, heading_level)
              File "/Users/andrew/mambaforge/envs/docker/lib/python3.9/site-packages/mkdocstrings/extension.py", line 185, in _process_block
                warn(
```

Tested here https://github.com/PrefectHQ/prefect-docker/pull/19