### PR TITLE
Bumps GH Pages deploy action version in template

### DIFF
--- a/{{cookiecutter.collection_name}}/.github/workflows/publish-docs.yml
+++ b/{{cookiecutter.collection_name}}/.github/workflows/publish-docs.yml
@@ -18,7 +18,7 @@ jobs:
           mkdocs build
 
       - name: Publish docs
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: docs
           folder: site

--- a/{{cookiecutter.collection_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.collection_name}}/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           mkdocs build
 
       - name: Publish docs
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: docs
           folder: site


### PR DESCRIPTION
Got a bunch of PRs from dependabot for the GH pages deploy action. Bumping the version in the template so that new collection get the most recent version.