### PR TITLE
Adds `conftest.py` with useful test fixtures

### DIFF
--- a/{{cookiecutter.collection_name}}/tests/conftest.py
+++ b/{{cookiecutter.collection_name}}/tests/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+from prefect.testing.utilities import prefect_test_harness
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prefect_db():
+    """
+    Sets up test harness for temporary DB during test runs.
+    """
+    with prefect_test_harness():
+        yield
+
+
+@pytest.fixture(autouse=True)
+def reset_object_registry():
+    """
+    Ensures each test has a clean object registry.
+    """
+    from prefect.context import PrefectObjectRegistry
+
+    with PrefectObjectRegistry():
+        yield


### PR DESCRIPTION
Creates a `conftest.py` file for the template with a couple of useful test fixtures.
- The `reset_object_registry` fixture prevents error messages like this from cluttering the logs of test runs:
    ```  /opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/site-packages/prefect/flows.py:202: UserWarning: A flow named 'bar' and defined at '/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/site-packages/prefect/testing/standard_test_suites/task_runners.py:562' conflicts with another flow. Consider specifying a unique `name` parameter in the flow definition:```
- The 'prefect_db` fixture uses the `prefect_test_harness` to set up a temporary DB for test runs to avoid potential conflicts with the runner's current environment.