### PR TITLE
Override caplog

### DIFF
--- a/{{cookiecutter.collection_name}}/tests/conftest.py
+++ b/{{cookiecutter.collection_name}}/tests/conftest.py
@@ -20,3 +20,20 @@ def reset_object_registry():
 
     with PrefectObjectRegistry():
         yield
+
+
+@pytest.fixture
+def caplog(caplog):
+    """
+    Overrides caplog to apply to all of our loggers that do not propagate and
+    consequently would not be captured by caplog.
+    """
+
+    config = setup_logging()
+
+    for name, logger_config in config["loggers"].items():
+        if not logger_config.get("propagate", True):
+            logger = get_logger(name)
+            logger.handlers.append(caplog.handler)
+
+    yield caplog

--- a/{{cookiecutter.collection_name}}/tests/conftest.py
+++ b/{{cookiecutter.collection_name}}/tests/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+from prefect.logging.configuration import setup_logging
+from prefect.logging.loggers import get_logger
 from prefect.testing.utilities import prefect_test_harness
 
 


### PR DESCRIPTION
Overrides caplog to apply to all of our loggers that do not propagate and consequently would not be captured by caplog. Taken from Michael.