### PR TITLE
Remove .credentials suffix in command

### DIFF
--- a/{{cookiecutter.collection_name}}/README.md
+++ b/{{cookiecutter.collection_name}}/README.md
@@ -41,7 +41,7 @@ pip install {{ cookiecutter.collection_name }}
 Then, register to [view the block](https://orion-docs.prefect.io/ui/blocks/) on Prefect Cloud:
 
 ```bash
-prefect block register -m {{ cookiecutter.collection_slug }}.credentials
+prefect block register -m {{ cookiecutter.collection_slug }}
 ```
 
 Note, to use the `load` method on Blocks, you must already have a block document [saved through code](https://orion-docs.prefect.io/concepts/blocks/#saving-blocks) or [saved through the UI](https://orion-docs.prefect.io/ui/blocks/).


### PR DESCRIPTION
Since we're exposing most blocks on top level.