### PR TITLE
add readme example to encourage contributors to highlight `with_options`

### DIFF
--- a/{{cookiecutter.collection_name}}/README.md
+++ b/{{cookiecutter.collection_name}}/README.md
@@ -71,6 +71,8 @@ def example_flow():
 example_flow()
 ```
 
+For more tips on how to use tasks and flows in a Collection, check out [Using Collections](https://orion-docs.prefect.io/collections/usage/)!
+
 ## Resources
 
 If you encounter any bugs while using `{{ cookiecutter.collection_name }}`, feel free to open an issue in the [{{ cookiecutter.collection_name }}](https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.collection_name }}) repository.

--- a/{{cookiecutter.collection_name}}/README.md
+++ b/{{cookiecutter.collection_name}}/README.md
@@ -59,7 +59,7 @@ from {{ cookiecutter.collection_slug }}.tasks import (
 
 custom_goodbye_{{ cookiecutter.collection_slug }} = goodbye_{{ cookiecutter.collection_slug }}.with_options(
     name="My custom task name",
-    max_retries=2,
+    retries=2,
     retry_delay_seconds=10,
 )
 

--- a/{{cookiecutter.collection_name}}/README.md
+++ b/{{cookiecutter.collection_name}}/README.md
@@ -55,7 +55,7 @@ from {{ cookiecutter.collection_slug }}.tasks import (
     hello_{{ cookiecutter.collection_slug }},
 )
 
-# Use `with_options` to customize settings on a task or flow defined in {{ cookiecutter.collection_slug }}:
+# Use `with_options` to customize options on any existing task or flow:
 
 custom_goodbye_{{ cookiecutter.collection_slug }} = goodbye_{{ cookiecutter.collection_slug }}.with_options(
     name="My custom task name",

--- a/{{cookiecutter.collection_name}}/README.md
+++ b/{{cookiecutter.collection_name}}/README.md
@@ -64,6 +64,25 @@ def example_flow():
 example_flow()
 ```
 
+To adjust settings on a pre-configured task or flow defined in a collection, use `with_options`:
+
+```python
+from prefect import flow
+from {{ cookiecutter.collection_slug }}.tasks import task_defined_in_{{ cookiecutter.collection_slug }}
+
+task_with_custom_settings = task_defined_in_{{ cookiecutter.collection_slug }}.with_options(
+    name="My custom task name",
+    max_retries=2,
+    retry_delay_seconds=10,
+)
+
+@flow
+def example_flow():
+    task_with_custom_settings()
+
+example_flow()
+```
+
 ## Resources
 
 If you encounter any bugs while using `{{ cookiecutter.collection_name }}`, feel free to open an issue in the [{{ cookiecutter.collection_name }}](https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecutter.collection_name }}) repository.

--- a/{{cookiecutter.collection_name}}/README.md
+++ b/{{cookiecutter.collection_name}}/README.md
@@ -64,7 +64,7 @@ def example_flow():
 example_flow()
 ```
 
-To adjust settings on a pre-configured task or flow defined in a collection, use `with_options`:
+To adjust settings on a pre-configured task or flow defined in {{ cookiecutter.collection_slug }}, use `with_options`:
 
 ```python
 from prefect import flow

--- a/{{cookiecutter.collection_name}}/README.md
+++ b/{{cookiecutter.collection_name}}/README.md
@@ -55,22 +55,9 @@ from {{ cookiecutter.collection_slug }}.tasks import (
     hello_{{ cookiecutter.collection_slug }},
 )
 
+# Use `with_options` to customize settings on a task or flow defined in {{ cookiecutter.collection_slug }}:
 
-@flow
-def example_flow():
-    hello_{{ cookiecutter.collection_slug }}
-    goodbye_{{ cookiecutter.collection_slug }}
-
-example_flow()
-```
-
-To adjust settings on a pre-configured task or flow defined in {{ cookiecutter.collection_slug }}, use `with_options`:
-
-```python
-from prefect import flow
-from {{ cookiecutter.collection_slug }}.tasks import task_defined_in_{{ cookiecutter.collection_slug }}
-
-task_with_custom_settings = task_defined_in_{{ cookiecutter.collection_slug }}.with_options(
+custom_goodbye_{{ cookiecutter.collection_slug }} = goodbye_{{ cookiecutter.collection_slug }}.with_options(
     name="My custom task name",
     max_retries=2,
     retry_delay_seconds=10,
@@ -78,7 +65,8 @@ task_with_custom_settings = task_defined_in_{{ cookiecutter.collection_slug }}.w
 
 @flow
 def example_flow():
-    task_with_custom_settings()
+    hello_{{ cookiecutter.collection_slug }}
+    custom_goodbye_{{ cookiecutter.collection_slug }}
 
 example_flow()
 ```


### PR DESCRIPTION
Michael Adkins
  [3 hours ago](https://prefect-community.slack.com/archives/CL09KU1K7/p1671037214855049?thread_ts=1671036767.096229&cid=CL09KU1K7)
[@alex](https://prefect-community.slack.com/team/U02GE39K551)
 it’d be good to highlight with_options in collections documentation especially, since they are “preconfigured”