### PR TITLE
rm trailing forward slash on link to block catalog

### DIFF
--- a/{{cookiecutter.collection_name}}/README.md
+++ b/{{cookiecutter.collection_name}}/README.md
@@ -38,7 +38,7 @@ Install `{{ cookiecutter.collection_name }}` with `pip`:
 pip install {{ cookiecutter.collection_name }}
 ```
 
-A list of available blocks in `{{ cookiecutter.collection_name }}` and their setup instructions can be found [here](https://{{ cookiecutter.github_organization }}.github.io/{{ cookiecutter.collection_name }}/#blocks-catalog/).
+A list of available blocks in `{{ cookiecutter.collection_name }}` and their setup instructions can be found [here](https://{{ cookiecutter.github_organization }}.github.io/{{ cookiecutter.collection_name }}/#blocks-catalog).
 
 ### Write and run a flow
 


### PR DESCRIPTION
Link [here](https://github.com/PrefectHQ/prefect-collection-template/blob/main/%7B%7Bcookiecutter.collection_name%7D%7D/README.md?plain=1#L41) to block catalog (e.g. [prefect-airbyte's link](https://prefecthq.github.io/prefect-airbyte/#blocks-catalog/)) has an extra forward slash that takes you to the top of the page instead of the Block Catalog markdown header as expected.