### PR TITLE
Add mkdocs build to static analysis

### DIFF
--- a/{{cookiecutter.collection_name}}/.github/workflows/static_analysis.yml
+++ b/{{cookiecutter.collection_name}}/.github/workflows/static_analysis.yml
@@ -25,3 +25,7 @@ jobs:
       - name: Run pre-commit
         run: |
           pre-commit run --show-diff-on-failure --color=always --all-files
+
+      - name: Run mkdocs build
+        run: |
+          mkdocs build --verbose --clean


### PR DESCRIPTION
Ensure docs can be built.
Closes https://github.com/PrefectHQ/prefect-collection-template/issues/104