### PR TITLE
Move mkdocs to tests workflow

### DIFF
--- a/{{cookiecutter.collection_name}}/.github/workflows/static_analysis.yml
+++ b/{{cookiecutter.collection_name}}/.github/workflows/static_analysis.yml
@@ -25,7 +25,3 @@ jobs:
       - name: Run pre-commit
         run: |
           pre-commit run --show-diff-on-failure --color=always --all-files
-
-      - name: Run mkdocs build
-        run: |
-          mkdocs build --verbose --clean

--- a/{{cookiecutter.collection_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.collection_name}}/.github/workflows/tests.yml
@@ -35,3 +35,7 @@ jobs:
         run: |
           coverage run --branch -m pytest tests -vv
           coverage report
+
+      - name: Run mkdocs build
+        run: |
+          mkdocs build --verbose --clean


### PR DESCRIPTION
Primarily because static analysis doesn't have the dependencies installed and crashes