### PR TITLE
Remove stripping whitespace

### DIFF
--- a/{{cookiecutter.collection_name}}/mkdocs.yml
+++ b/{{cookiecutter.collection_name}}/mkdocs.yml
@@ -66,8 +66,7 @@ nav:
     - Home: index.md
     - Tasks: tasks.md
     - Flows: flows.md
-
-{%- if cookiecutter.github_organization.lower() == "prefecthq" -%}
+{% if cookiecutter.github_organization.lower() == "prefecthq" %}
 extra:
     social:
         - icon: fontawesome/brands/slack


### PR DESCRIPTION
The `-` removed the whitespace, resulting in two lines flows.md + extra mashed together, when the desired behavior is for them to be separated.
![image](https://user-images.githubusercontent.com/15331990/211402897-3adc5add-c322-44fa-bf0a-582aa1d79f35.png)
