### PR TITLE
Add google analytics

### DIFF
--- a/{{cookiecutter.collection_name}}/mkdocs.yml
+++ b/{{cookiecutter.collection_name}}/mkdocs.yml
@@ -93,4 +93,7 @@ extra:
           link: https://hub.docker.com/r/prefecthq/prefect/
         - icon: fontawesome/brands/python
           link: https://pypi.org/project/prefect/
+    analytics:
+        provider: google
+        property: G-8CSMBCQDKN
 {% endif %}


### PR DESCRIPTION
Got this from Reuter; this will help us see how users come to our docs page; a single one could be sufficient for all our Collections since we can do separate reports based on the URL or title of the page