### PR TITLE
Create Windows tests workflow

### DIFF
--- a/{{cookiecutter.collection_name}}/.github/workflows/windows-tests.yml
+++ b/{{cookiecutter.collection_name}}/.github/workflows/windows-tests.yml
@@ -1,0 +1,34 @@
+
+name: Windows Tests
+
+on: [pull_request]
+
+jobs:
+  run-tests:
+    name: Run Tests
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        # Prefect only tests 3.9 on Windows
+        python-version:
+          - "3.9"
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements*.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade --upgrade-strategy eager -e ".[dev]"
+      - name: Run tests
+        env:
+          PREFECT_ORION_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./orion-tests.db"
+        run: |
+          pytest tests -vv


### PR DESCRIPTION
Our analytics show nearly half of our users use Windows so we should add Windows tests to ensure that we're not breaking their flows.