### PR TITLE
Fix mkdocs with custom analytics

### DIFF
--- a/{{cookiecutter.collection_name}}/mkdocs.yml
+++ b/{{cookiecutter.collection_name}}/mkdocs.yml
@@ -4,6 +4,7 @@ repo_url: https://github.com/{{ cookiecutter.github_organization }}/{{ cookiecut
 edit_uri: edit/main/docs/
 theme:
   name: material
+  custom_dir: docs/overrides
   favicon: img/favicon.ico
   palette:
     - media: "(prefers-color-scheme)"


### PR DESCRIPTION
Else it results in 
```

  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/material/partials/integrations/analytics.html", line 8, in top-level template code
    {% include "partials/integrations/analytics/" ~ provider ~ ".html" %}
  File "/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/jinja2/loaders.py", line 218, in get_source
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: partials/integrations/analytics/custom.html
```