### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/{{cookiecutter.collection_name}}/.github/workflows/nightly-dev-tests.yml
+++ b/{{cookiecutter.collection_name}}/.github/workflows/nightly-dev-tests.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/{{cookiecutter.collection_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.collection_name}}/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install packages
         run: |

--- a/{{cookiecutter.collection_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.collection_name}}/.github/workflows/tests.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/{{cookiecutter.collection_name}}/MAINTAINERS.md
+++ b/{{cookiecutter.collection_name}}/MAINTAINERS.md
@@ -6,7 +6,7 @@ Now that you've bootstrapped a project, follow the steps below to get started de
 
 ### Python setup
 
-Requires an installation of Python 3.7+
+Requires an installation of Python 3.8+
 
 We recommend using a Python virtual environment manager such as pipenv, conda or virtualenv.
 

--- a/{{cookiecutter.collection_name}}/README.md
+++ b/{{cookiecutter.collection_name}}/README.md
@@ -47,7 +47,7 @@ Install `{{ cookiecutter.collection_name }}` with `pip`:
 pip install {{ cookiecutter.collection_name }}
 ```
 
-Requires an installation of Python 3.7+.
+Requires an installation of Python 3.8+.
 
 We recommend using a Python virtual environment manager such as pipenv, conda or virtualenv.
 

--- a/{{cookiecutter.collection_name}}/setup.py
+++ b/{{cookiecutter.collection_name}}/setup.py
@@ -24,7 +24,7 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     packages=find_packages(exclude=("tests", "docs")),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=install_requires,
     extras_require={"dev": dev_requires},
     entry_points={
@@ -38,7 +38,6 @@ setup(
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Removes Python 3.7 support, as Prefect just did (see [PrefectHQ/prefect#10156](https://github.com/issues/10156)), making the template compatible with Python 3.8+.

This should fix the (nightly) tests actions, which try to run tests again Prefect's main branch.

