### PR TITLE
Remove python3.8 nightly test

### DIFF
--- a/{{cookiecutter.collection_name}}/.github/workflows/nightly-dev-tests.yml
+++ b/{{cookiecutter.collection_name}}/.github/workflows/nightly-dev-tests.yml
@@ -13,6 +13,8 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/{{cookiecutter.collection_name}}/.github/workflows/nightly-dev-tests.yml
+++ b/{{cookiecutter.collection_name}}/.github/workflows/nightly-dev-tests.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
       fail-fast: false

--- a/{{cookiecutter.collection_name}}/requirements.txt
+++ b/{{cookiecutter.collection_name}}/requirements.txt
@@ -1,1 +1,1 @@
-prefect>=2.0.0
+prefect<3.0.0

--- a/{{cookiecutter.collection_name}}/{{cookiecutter.collection_slug}}/blocks.py
+++ b/{{cookiecutter.collection_name}}/{{cookiecutter.collection_slug}}/blocks.py
@@ -1,7 +1,12 @@
 """This is an example blocks module"""
 
 from prefect.blocks.core import Block
-from pydantic import Field
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field
+else:
+    from pydantic import Field
 
 
 class {{ cookiecutter.collection_name.split('-')[1:] | join | title}}Block(Block):


### PR DESCRIPTION
Removes python 3.8 nightly test; this is causing collections nightly tests to fail, as latest Prefect 3.x doesn't support it - see PrefectHQ/prefect#13331